### PR TITLE
Issue when creating Javascript Date objects

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -90,12 +90,12 @@
                 } else if (gdatatype === 'date') {
                     //assume format yyyy-MM-dd
                     newvalue = new Date(value.substr(0, 4),
-                                        value.substr(5, 2),
+                                        parseInt(value.substr(5, 2))-1,
                                         value.substr(8, 2));
                 } else if (gdatatype === 'datetime') {
                     //assume format yyyy-MM-ddZHH:mm:ss
                     newvalue = new Date(value.substr(0, 4),
-                                        value.substr(5, 2),
+                                        parseInt(value.substr(5, 2))-1,
                                         value.substr(8, 2),
                                         value.substr(11, 2),
                                         value.substr(14, 2),


### PR DESCRIPTION
The month part of a Date object in Javascript is 0-based (January = 0, February = 1, etc.). Thus, it is needed to subtract 1 to the actual month (either in xsd:date or xsd:dateTime) returned by a SPARQL query.
